### PR TITLE
Fixed current in pagination logic in BlogIndexPage.astro

### DIFF
--- a/src/templates/BlogIndexPage.astro
+++ b/src/templates/BlogIndexPage.astro
@@ -16,7 +16,7 @@ const pages = [];
 for (let i = 1; (i <= totalPages); i++) {
   pages.push({
     number: i,
-    current: page === currentPage,
+    current: i === currentPage,
     url: setParameter(Astro.url, 'page', i)
   });
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

In `BlogIndexPage.astro`, there was the line `page === currentPage`. The problem is that `page` is an object while `currentPage` is a number, so that comparison was always `false.` Now, it has been fixed.

## What are the specific steps to test this change?
1. Run the site
2. Log in as an admin
3. Create more than 10 blog posts
4. Verify that the pagination element matching the current page has the "current" class

## What kind of change does this PR introduce?

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
